### PR TITLE
 Modify The Core API To Run Arbitrary Effects And Add onMax Event

### DIFF
--- a/core/src/test/scala/io/isomarcte/http4s/active/requests/core/ActiveRequestMiddlewareTest.scala
+++ b/core/src/test/scala/io/isomarcte/http4s/active/requests/core/ActiveRequestMiddlewareTest.scala
@@ -5,6 +5,7 @@ import cats.effect._
 import cats.implicits._
 import io.isomarcte.http4s.active.requests.core._
 import java.util.concurrent._
+import java.util.concurrent.atomic._
 import org.http4s._
 import org.http4s.server._
 import scala.concurrent._
@@ -12,14 +13,17 @@ import scala.concurrent._
 final class ActiveRequestMiddlewareTest extends BaseTest {
 
   "serviceUnavailableMiddleware" should "reject requests if there are too many concurrently running" in io {
-    val ec: ExecutionContext  = BaseTest.cachedEC
-    val limit: Int            = 1
-    val latch: CountDownLatch = new CountDownLatch(2)
-    val semaphore: Semaphore  = new Semaphore(limit)
-    val request: Request[IO]  = Request[IO]()
-    val f: IO[Unit]           = IO(latch.countDown()) *> IO(semaphore.acquire())
+    val ec: ExecutionContext      = BaseTest.cachedEC
+    val limit: Int                = 1
+    val latch: CountDownLatch     = new CountDownLatch(2)
+    val semaphore: Semaphore      = new Semaphore(limit)
+    val onMaxCount: AtomicInteger = new AtomicInteger(0)
+    val request: Request[IO]      = Request[IO]()
+    val f: IO[Unit]               = IO(latch.countDown()) *> IO(semaphore.acquire())
+    val onMax: IO[Unit]           = IO(onMaxCount.incrementAndGet()).void
     val (activeRequests, middleware): (IO[Long], HttpMiddleware[IO]) =
       ActiveRequestMiddleware.serviceUnavailableMiddleware_[IO, Long](
+        onMax,
         limit.toLong
       )
     val service: HttpService[IO] =
@@ -34,7 +38,8 @@ final class ActiveRequestMiddlewareTest extends BaseTest {
       // Out of permits so this will block. We will join the Fiber later
       fiber1 <- (IO.shift(ec) *> service.run(request).value).start
 
-      // Wait for the inner effect to run before we poll the activeRequest state.
+      // Wait for the latch to reach zero before we poll. This should indicate
+      // that we have already incremented the counter.
       _ <- IO(latch.await())
       count1 <- activeRequests // Should be 1
 
@@ -48,6 +53,7 @@ final class ActiveRequestMiddlewareTest extends BaseTest {
       _ <- IO(semaphore.release())
       resp1 <- fiber1.join // Should be Ok
       count3 <- activeRequests // Should be 0
+      onMaxValue <- IO(onMaxCount.get)
     } yield {
       // T0
       resp0.get.status shouldBe Status.Ok
@@ -63,6 +69,9 @@ final class ActiveRequestMiddlewareTest extends BaseTest {
 
       // T3
       count3 shouldBe 0L
+
+      // Check number of times the onMax event fired
+      onMaxValue shouldBe 1
     }
   }
 }


### PR DESCRIPTION
Some awkwardness was discovered in having the `primitive` API method encapsulate a state value directly. This commit changes the core API to merely call two effects at the start and end of the http transaction.

This commit also adds an `onMax` effect to the higher level APIs which is invoked when the number of concurrent requests exceeds the specified limit. While the polling effect is still useful for use cases such as metrics, it can not be used to know the _exact_ moment we go over the limit due to the concurrent nature of the value.